### PR TITLE
Language codes are defined in whisper.cpp

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,6 +88,9 @@ The repository includes a lot of code which was only used for development:
 couple alternative model implementations, compatible FP64 versions of some compute shaders, debug tracing and the tool to compare the traces, etc.<br/>
 That stuff is disabled by preprocessor macros or `constexpr` flags, I hope it’s fine to keep here.
 
+The `--language` option for the main.exe takes language codes defined in [Whisper/source/whisper.cpp](Whisper/source/whisper.cpp), 
+for example `en` for English, `zh` for Chinese, etc.
+
 ## Performance Notes
 
 I have a limited selection of GPUs in this house.<br/>


### PR DESCRIPTION
I use main.exe for scripting, but I had no idea what these language codes were. I debugged into the program and learned that they are defined in whisper.cpp.

Hence, I decide to add some explanation to this repository. But I didn't find a place where you explain the command line options, so I just add my explanation in the Other Notes section.